### PR TITLE
Allow venue image to be full width on mobile

### DIFF
--- a/source/parts/_the-venue.html.erb
+++ b/source/parts/_the-venue.html.erb
@@ -1,7 +1,7 @@
 <div class="flex">
   <div class="mx-auto text-center">
     <h2>Venue</h2>
-    <%= image_tag 'house.jpeg', alt: 'Warra Gnan Coastal Camp', class: 'mx-auto my-4 rounded-lg' %>
+    <%= image_tag 'house.jpeg', alt: 'Warra Gnan Coastal Camp', class: 'max-w-full my-4 rounded-lg' %>
     <div class="blurb">
       <p><a target="_blank" href="https://maps.app.goo.gl/dqC2XaLUVQwCA1e56">
         Warra Gnan Coastal Camp,


### PR DESCRIPTION
Changes in this PR:

- [x] Switch CSS class applied to main venue photo

Why:

The width of main venue photo breaks mobile viewport:

| Before | After |
| --- | --- |
| ![Screenshot 2024-06-04 at 10-56-23 Ruby Retreat 2024](https://github.com/rubyaustralia/Ruby-Retreat-2024/assets/924/b4395374-c748-4614-a82a-137d60651bab) | ![Screenshot 2024-06-04 at 11-00-59 Ruby Retreat 2024](https://github.com/rubyaustralia/Ruby-Retreat-2024/assets/924/423d3d72-6d39-4e43-8bcb-31060ecf939e) |
